### PR TITLE
Fix typo in the CLI suggestion for `bpftrace`

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -20,7 +20,7 @@ try {
     }
 
     Console.WriteLine($"Ready! Trace me with:");
-    Console.WriteLine("   sudo bpftrace -p (pgrep DynamicProbes) -e 'usdt:*:myprovider:myprobe { printf(\"Fired values: %ld %lu\\n\", arg0, arg1); }'");
+    Console.WriteLine("   sudo bpftrace -p $(pgrep DynamicProbes) -e 'usdt:*:myprovider:myprobe { printf(\"Fired values: %ld %lu\\n\", arg0, arg1); }'");
 
     while (true) {
         var val = ulong.MinValue;


### PR DESCRIPTION
The current suggested command-line for `bpftrace` trace produces the error:

    -bash: syntax error near unexpected token `('

Assuming it's designed for Bash, the `$` seems to be missing, which is what this PR fixes.