### PR TITLE
Set the runtime identifier (RID) for Linux

### DIFF
--- a/DynamicProbes.csproj
+++ b/DynamicProbes.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
+    <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
Since this project is specific to the Linux platform, this PR [sets the runtime identifier](https://learn.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#runtimeidentifier) to [`linux-x64`](https://learn.microsoft.com/en-us/dotnet/core/rid-catalog).