### PR TITLE
Print PID in lieu of potentially ambiguous `bgrep` result

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -20,7 +20,7 @@ try {
     }
 
     Console.WriteLine($"Ready! Trace me with:");
-    Console.WriteLine("   sudo bpftrace -p (pgrep DynamicProbes) -e 'usdt:*:myprovider:myprobe { printf(\"Fired values: %ld %lu\\n\", arg0, arg1); }'");
+    Console.WriteLine($$"""   sudo bpftrace -p {{Environment.ProcessId}} -e 'usdt:*:myprovider:myprobe { printf("Fired values: %ld %lu\n", arg0, arg1); }'""");
 
     while (true) {
         var val = ulong.MinValue;


### PR DESCRIPTION
The `pgrep DynamicProbes` suggestion has 3 problems:

1. It has a typo (per Bash) for which a fix has been submitted as PR #1. 
2. When using `dotnet run`:
   https://github.com/gukoff/DynamicProbes/blob/8ff26e2e44a9eb52dd4c8813d135a45c701f9538/README.md?plain=1#L15
   as the read-me suggestion, the process appears as `dotnet` instead of `DynamicProbes` so `pgrep` doesn't work and leads to confusion.
4. Using `pgrep dotnet` could give ambiguous results as there could be many such processes running.

This PR directly advertises the PID. It also uses a raw string so `\n` and quotes don't need escaping for readability.
