### PR TITLE
Use `StringToCoTaskMemUTF8` to make UTF-8 encoding clear

### DIFF
--- a/src/Program.cs
+++ b/src/Program.cs
@@ -26,14 +26,14 @@ try {
     while (true) {
         var val = ulong.MinValue;
         var isoTimeString = DateTime.Now.ToString("O", CultureInfo.InvariantCulture);
-        var isoTimeStringPtr = Marshal.StringToHGlobalAnsi(isoTimeString);
+        var isoTimeStringPtr = Marshal.StringToCoTaskMemUTF8(isoTimeString);
         try
         {
             Libstapsdt.Libstapsdt.probeFire(probe, long.MinValue, isoTimeStringPtr);
         }
         finally
         {
-            Marshal.FreeHGlobal(isoTimeStringPtr);
+            Marshal.FreeCoTaskMem(isoTimeStringPtr);
         }
         Console.WriteLine("Probe fired! Probe is currently {0}", Libstapsdt.Libstapsdt.probeIsEnabled(probe) ? "watched" : "not watched");
         Thread.Sleep(500);


### PR DESCRIPTION
Based on [the discoveries in my comment PR #8](https://github.com/gukoff/DynamicProbes/pull/8#issuecomment-2328404677), this PR replaces the use of `Marshal.StringToHGlobalAnsi` with `Marshal.StringToCoTaskMemUTF8` to make it obvious that the string for the unmanaged/interoperability counterpart is using the UTF-8 encoding and therefore there isn't risk of character corruption as originally feared.
