### PR TITLE
[CI] Benchmark calling the probe

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -41,6 +41,13 @@ jobs:
       - name: Run benchmark
         run: cd benchmark && dotnet run --exporters json --filter '*' -c Release
 
+      # Download previous benchmark result from cache (if exists)
+      - name: Download previous benchmark data
+        uses: actions/cache@v4
+        with:
+          path: ./cache
+          key: last-benchmark
+
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1
         with:

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -58,7 +58,7 @@ jobs:
       # This step does multiple things:
       # - compares these benchmark results with the latest benchmark in the main branch;
       # - prints the comparison to the CI run summary
-      # - posts the comparison as a PR comment. If a comments already exists, updates it.
+      # - posts the comparison as a PR comment, but updates the comment if it already exists.
       - name: Publish benchmark result
         uses: gukoff/github-action-benchmark@short-floats  # custom fork of the action that succinctly formats float values in the report
         with:

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -61,10 +61,10 @@ jobs:
       #   with:
       #     filePath: benchmark/BenchmarkDotNet.Artifacts/results/Benchmark.NotObservedProbeFireBenchmarks-report-github.md
 
-      - name: Store benchmark result
-        uses: benchmark-action/github-action-benchmark@v1
+      - name: Publish benchmark result
+        uses: benchmark-action/github-action-benchmark@master
         with:
-          name: Benchmark.Net Benchmark
+          name: Benchmark (compared to main)
           tool: 'benchmarkdotnet'
           output-file-path: benchmark/BenchmarkDotNet.Artifacts/results/Benchmark.NotObservedProbeFireBenchmarks-report-full-compressed.json
           external-data-json-path: ./cache/benchmark-data.json

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -71,8 +71,7 @@ jobs:
           comment-always: true
           # Caveat: https://github.com/benchmark-action/github-action-benchmark?tab=readme-ov-file#caveats
           # When triggering on PRs, it's important to have this action "read-only"
-          # save-data-file: ${{ github.event_name != 'pull_request' }}
-          save-data-file: true
+          save-data-file: ${{ github.event_name != 'pull_request' }}
           alert-threshold: '200%'
           comment-on-alert: true
           fail-on-alert: true

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -8,7 +8,6 @@ on:
     branches:
       - main
 
-
 jobs:
   benchmark:
     name: Run benchmark
@@ -64,7 +63,7 @@ jobs:
       - name: Publish benchmark result
         uses: gukoff/github-action-benchmark@short-floats
         with:
-          name: Benchmark (compared to main)
+          name: Benchmark (compared to main)  # bench data is cached inside `external-data-json-path` by this name
           tool: 'benchmarkdotnet'
           output-file-path: benchmark/BenchmarkDotNet.Artifacts/results/Benchmark.NotObservedProbeFireBenchmarks-report-full-compressed.json
           external-data-json-path: ./cache/benchmark-data.json
@@ -73,7 +72,8 @@ jobs:
           comment-always: true
           # Caveat: https://github.com/benchmark-action/github-action-benchmark?tab=readme-ov-file#caveats
           # When triggering on PRs, it's important to have this action "read-only"
-          save-data-file: ${{ github.event_name != 'pull_request' }}
+          # save-data-file: ${{ github.event_name != 'pull_request' }}
+          save-data-file: true
           alert-threshold: '200%'
           comment-on-alert: true
           fail-on-alert: true

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -57,7 +57,7 @@ jobs:
 
       # This step does multiple things:
       # - compares these benchmark results with the latest benchmark in the main branch;
-      # - prints the comparison to the CI run sumary
+      # - prints the comparison to the CI run summary
       # - posts the comparison as a PR comment. If a comments already exists, updates it.
       - name: Publish benchmark result
         uses: gukoff/github-action-benchmark@short-floats  # custom fork of the action that succinctly formats float values in the report

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -2,6 +2,8 @@ name: Benchmark
 
 on:
   push:
+    branches:
+      - main
   pull_request:
     branches:
       - main
@@ -38,33 +40,33 @@ jobs:
           path: DynamicProbes
 
       - name: Install dotnet
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '8.0.401'
 
       - name: Run benchmark
         run: cd DynamicProbes/benchmark && dotnet run --exporters json --filter '*' -c Release
 
-      # - name: Store benchmark result
-      #   uses: rhysd/github-action-benchmark@v1
-      #   with:
-      #     name: Benchmark.Net Benchmark
-      #     tool: 'benchmarkdotnet'
-      #     output-file-path: examples/benchmarkdotnet/BenchmarkDotNet.Artifacts/results/Sample.Benchmarks-report-full-compressed.json
-      #     github-token: ${{ secrets.GITHUB_TOKEN }}
-      #     auto-push: true
-      #     # Show alert with commit comment on detecting possible performance regression
-      #     alert-threshold: '200%'
-      #     comment-on-alert: true
-      #     fail-on-alert: true
-      #     alert-comment-cc-users: '@ktrz'
+      - name: Store benchmark result
+        uses: rhysd/github-action-benchmark@v1
+        with:
+          name: Benchmark.Net Benchmark
+          tool: 'benchmarkdotnet'
+          output-file-path: DynamicProbes/benchmark/BenchmarkDotNet.Artifacts/results/Sample.Benchmarks-report-full-compressed.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          # Show alert with commit comment on detecting possible performance regression
+          alert-threshold: '200%'
+          comment-on-alert: true
+          fail-on-alert: true
+          alert-comment-cc-users: '@gukoff'
 
       # - name: Store benchmark result - separate results repo
       #   uses: rhysd/github-action-benchmark@v1
       #   with:
       #     name: Benchmark.Net Benchmark
       #     tool: 'benchmarkdotnet'
-      #     output-file-path: examples/benchmarkdotnet/BenchmarkDotNet.Artifacts/results/Sample.Benchmarks-report-full-compressed.json
+      #     output-file-path: DynamicProbes/benchmark/BenchmarkDotNet.Artifacts/results/Sample.Benchmarks-report-full-compressed.json
       #     github-token: ${{ secrets.BENCHMARK_ACTION_BOT_TOKEN }}
       #     auto-push: true
       #     # Show alert with commit comment on detecting possible performance regression

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -50,7 +50,7 @@ jobs:
         with:
           name: Benchmark.Net Benchmark
           tool: 'benchmarkdotnet'
-          output-file-path: benchmark/BenchmarkDotNet.Artifacts/results/Sample.Benchmarks-report-full-compressed.json
+          output-file-path: benchmark/BenchmarkDotNet.Artifacts/results/NotObservedProbeFireBenchmarks.Benchmarks-report-full-compressed.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
           auto-push: true
           # Show alert with commit comment on detecting possible performance regression

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -45,12 +45,16 @@ jobs:
       - name: Run benchmark
         run: cd benchmark && dotnet run --exporters json --filter '*' -c Release
 
+      - uses: philips-labs/list-folders-action@v1
+        with:
+          path: benchmark/BenchmarkDotNet.Artifacts/results/
+
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1
         with:
           name: Benchmark.Net Benchmark
           tool: 'benchmarkdotnet'
-          output-file-path: benchmark/BenchmarkDotNet.Artifacts/results/NotObservedProbeFireBenchmarks.Benchmarks-report-full-compressed.json
+          output-file-path: benchmark/BenchmarkDotNet.Artifacts/results/Benchmark.NotObservedProbeFireBenchmarks-report-full-compressed.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
           auto-push: true
           # Show alert with commit comment on detecting possible performance regression

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -45,9 +45,12 @@ jobs:
       - name: Run benchmark
         run: cd benchmark && dotnet run --exporters json --filter '*' -c Release
 
-      - uses: philips-labs/list-folders-action@v1
-        with:
-          path: benchmark/BenchmarkDotNet.Artifacts/results/
+      - name: list folder
+        run: |
+          ls benchmark/BenchmarkDotNet.Artifacts/results
+          echo '---'
+          ls benchmark/BenchmarkDotNet.Artifacts/results/*
+        shell: bash
 
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -8,10 +8,6 @@ on:
     branches:
       - main
 
-# permissions:
-#   contents: write
-#   deployments: write
-
 jobs:
   benchmark:
     name: Run Benchmark.Net benchmark example
@@ -45,13 +41,6 @@ jobs:
       - name: Run benchmark
         run: cd benchmark && dotnet run --exporters json --filter '*' -c Release
 
-      - name: list folder
-        run: |
-          ls benchmark/BenchmarkDotNet.Artifacts/results
-          echo '---'
-          ls benchmark/BenchmarkDotNet.Artifacts/results/*
-        shell: bash
-
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1
         with:
@@ -66,18 +55,3 @@ jobs:
           comment-on-alert: true
           fail-on-alert: true
           alert-comment-cc-users: '@gukoff'
-
-      # - name: Store benchmark result - separate results repo
-      #   uses: rhysd/github-action-benchmark@v1
-      #   with:
-      #     name: Benchmark.Net Benchmark
-      #     tool: 'benchmarkdotnet'
-      #     output-file-path: DynamicProbes/benchmark/BenchmarkDotNet.Artifacts/results/Sample.Benchmarks-report-full-compressed.json
-      #     github-token: ${{ secrets.BENCHMARK_ACTION_BOT_TOKEN }}
-      #     auto-push: true
-      #     # Show alert with commit comment on detecting possible performance regression
-      #     alert-threshold: '200%'
-      #     comment-on-alert: true
-      #     fail-on-alert: true
-      #     alert-comment-cc-users: '@ktrz'
-      #     gh-repository: 'github.com/benchmark-action/github-action-benchmark-results'

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -71,7 +71,8 @@ jobs:
           comment-always: true
           # Caveat: https://github.com/benchmark-action/github-action-benchmark?tab=readme-ov-file#caveats
           # When triggering on PRs, it's important to have this action "read-only"
-          save-data-file: ${{ github.event_name != 'pull_request' }}
+          # save-data-file: ${{ github.event_name != 'pull_request' }}
+          save-data-file: true
           alert-threshold: '200%'
           comment-on-alert: true
           fail-on-alert: true

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -72,8 +72,7 @@ jobs:
           comment-always: true
           # Caveat: https://github.com/benchmark-action/github-action-benchmark?tab=readme-ov-file#caveats
           # When triggering on PRs, it's important to have this action "read-only"
-          # save-data-file: ${{ github.event_name != 'pull_request' }}
-          save-data-file: true
+          save-data-file: ${{ github.event_name != 'pull_request' }}
           alert-threshold: '200%'
           comment-on-alert: true
           fail-on-alert: true

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -64,7 +64,7 @@ jobs:
       # Caveat: https://github.com/benchmark-action/github-action-benchmark?tab=readme-ov-file#caveats
       # When triggering on PRs, it's important to have this action "read-only"
       - name: Store benchmark result
-        uses: gukoff/github-action-benchmark@short-floats
+        uses: gukoff/github-action-benchmark@main
         with:
           name: Benchmark.Net Benchmark
           tool: 'benchmarkdotnet'

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -46,7 +46,7 @@ jobs:
         run: cd benchmark && dotnet run --exporters json --filter '*' -c Release
 
       - name: Store benchmark result
-        uses: rhysd/github-action-benchmark@v1
+        uses: benchmark-action/github-action-benchmark@v1
         with:
           name: Benchmark.Net Benchmark
           tool: 'benchmarkdotnet'

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -48,6 +48,8 @@ jobs:
           path: ./cache
           key: last-benchmark
 
+      # Caveat: https://github.com/benchmark-action/github-action-benchmark?tab=readme-ov-file#caveats
+      # When triggering on PRs, it's important to have this action "read-only"
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1
         with:
@@ -57,6 +59,8 @@ jobs:
           external-data-json-path: ./cache/benchmark-data.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
           summary-always: true
+          comment-always: true
+          save-data-file: ${{ github.event_name != 'pull_request' }}
           # Show alert with commit comment on detecting possible performance regression
           alert-threshold: '200%'
           comment-on-alert: true

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -62,7 +62,7 @@ jobs:
       #     filePath: benchmark/BenchmarkDotNet.Artifacts/results/Benchmark.NotObservedProbeFireBenchmarks-report-github.md
 
       - name: Publish benchmark result
-        uses: benchmark-action/github-action-benchmark@master
+        uses: gukoff/github-action-benchmark@short-floats
         with:
           name: Benchmark (compared to main)
           tool: 'benchmarkdotnet'

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -25,6 +25,7 @@ jobs:
       - name: Install libstapsdt
         run: |
           set -euxo pipefail
+          sudo apt install libelf-dev
           cd libstapsdt
           make
           sudo make install

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -41,7 +41,7 @@ jobs:
           dotnet-version: '8.0.401'
 
       - name: Run benchmark
-        run: cd benchmark && dotnet run --exporters json --filter '*' -c Release
+        run: dotnet run --project benchmark -c Release
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -55,13 +55,12 @@ jobs:
           path: ./cache
           key: last-benchmark
 
-      # - name: PR comment with file
-      #   uses: thollander/actions-comment-pull-request@v2
-      #   with:
-      #     filePath: benchmark/BenchmarkDotNet.Artifacts/results/Benchmark.NotObservedProbeFireBenchmarks-report-github.md
-
+      # This step does multiple things:
+      # - compares these benchmark results with the latest benchmark in the main branch;
+      # - prints the comparison to the CI run sumary
+      # - posts the comparison as a PR comment. If a comments already exists, updates it.
       - name: Publish benchmark result
-        uses: gukoff/github-action-benchmark@short-floats
+        uses: gukoff/github-action-benchmark@short-floats  # custom fork of the action that succinctly formats float values in the report
         with:
           name: Benchmark (compared to main)  # bench data is cached inside `external-data-json-path` by this name
           tool: 'benchmarkdotnet'

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -72,7 +72,8 @@ jobs:
           comment-always: true
           # Caveat: https://github.com/benchmark-action/github-action-benchmark?tab=readme-ov-file#caveats
           # When triggering on PRs, it's important to have this action "read-only"
-          save-data-file: ${{ github.event_name != 'pull_request' }}
+          # save-data-file: ${{ github.event_name != 'pull_request' }}
+          save-data-file: true
           alert-threshold: '200%'
           comment-on-alert: true
           fail-on-alert: true

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -22,13 +22,13 @@ jobs:
         with:
           repository: linux-usdt/libstapsdt
           ref: refs/heads/main
-          path: libstapsdt
+          path: ext_libstapsdt
 
       - name: Install libstapsdt
         run: |
           set -euxo pipefail
           sudo apt install libelf-dev
-          cd libstapsdt
+          cd ext_libstapsdt
           make
           sudo make install
           sudo ldconfig
@@ -36,8 +36,6 @@ jobs:
 
       - name: Checkout DynamicProbes repo
         uses: actions/checkout@v4
-        with:
-          path: DynamicProbes
 
       - name: Install dotnet
         uses: actions/setup-dotnet@v4
@@ -45,14 +43,14 @@ jobs:
           dotnet-version: '8.0.401'
 
       - name: Run benchmark
-        run: cd DynamicProbes/benchmark && dotnet run --exporters json --filter '*' -c Release
+        run: cd benchmark && dotnet run --exporters json --filter '*' -c Release
 
       - name: Store benchmark result
         uses: rhysd/github-action-benchmark@v1
         with:
           name: Benchmark.Net Benchmark
           tool: 'benchmarkdotnet'
-          output-file-path: DynamicProbes/benchmark/BenchmarkDotNet.Artifacts/results/Sample.Benchmarks-report-full-compressed.json
+          output-file-path: benchmark/BenchmarkDotNet.Artifacts/results/Sample.Benchmarks-report-full-compressed.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
           auto-push: true
           # Show alert with commit comment on detecting possible performance regression

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -64,7 +64,7 @@ jobs:
       # Caveat: https://github.com/benchmark-action/github-action-benchmark?tab=readme-ov-file#caveats
       # When triggering on PRs, it's important to have this action "read-only"
       - name: Store benchmark result
-        uses: gukoff/github-action-benchmark@v2
+        uses: gukoff/github-action-benchmark@short-floats
         with:
           name: Benchmark.Net Benchmark
           tool: 'benchmarkdotnet'

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -62,7 +62,7 @@ jobs:
       #     filePath: benchmark/BenchmarkDotNet.Artifacts/results/Benchmark.NotObservedProbeFireBenchmarks-report-github.md
 
       - name: Store benchmark result
-        uses: gukoff/github-action-benchmark@short-floats
+        uses: benchmark-action/github-action-benchmark@v1
         with:
           name: Benchmark.Net Benchmark
           tool: 'benchmarkdotnet'

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -59,7 +59,7 @@ jobs:
       # Caveat: https://github.com/benchmark-action/github-action-benchmark?tab=readme-ov-file#caveats
       # When triggering on PRs, it's important to have this action "read-only"
       - name: Store benchmark result
-        uses: benchmark-action/github-action-benchmark@v1
+        uses: gukoff/github-action-benchmark@short-floats
         with:
           name: Benchmark.Net Benchmark
           tool: 'benchmarkdotnet'

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -61,8 +61,6 @@ jobs:
       #   with:
       #     filePath: benchmark/BenchmarkDotNet.Artifacts/results/Benchmark.NotObservedProbeFireBenchmarks-report-github.md
 
-      # Caveat: https://github.com/benchmark-action/github-action-benchmark?tab=readme-ov-file#caveats
-      # When triggering on PRs, it's important to have this action "read-only"
       - name: Store benchmark result
         uses: gukoff/github-action-benchmark@short-floats
         with:
@@ -73,8 +71,9 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           summary-always: true
           comment-always: true
+          # Caveat: https://github.com/benchmark-action/github-action-benchmark?tab=readme-ov-file#caveats
+          # When triggering on PRs, it's important to have this action "read-only"
           save-data-file: ${{ github.event_name != 'pull_request' }}
-          # Show alert with commit comment on detecting possible performance regression
           alert-threshold: '200%'
           comment-on-alert: true
           fail-on-alert: true

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -1,0 +1,52 @@
+name: Benchmark
+
+on:
+  push:
+  pull_request:
+    branches:
+      - main
+
+# permissions:
+#   contents: write
+#   deployments: write
+
+jobs:
+  benchmark:
+    name: Run Benchmark.Net benchmark example
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '8.0.401'  # SDK Version to use. keep in line with examples/benchmarkdotnet/global.json
+      - name: Run benchmark
+        run: cd benchmark && dotnet run --exporters json --filter '*' -c Release
+
+      # - name: Store benchmark result
+      #   uses: rhysd/github-action-benchmark@v1
+      #   with:
+      #     name: Benchmark.Net Benchmark
+      #     tool: 'benchmarkdotnet'
+      #     output-file-path: examples/benchmarkdotnet/BenchmarkDotNet.Artifacts/results/Sample.Benchmarks-report-full-compressed.json
+      #     github-token: ${{ secrets.GITHUB_TOKEN }}
+      #     auto-push: true
+      #     # Show alert with commit comment on detecting possible performance regression
+      #     alert-threshold: '200%'
+      #     comment-on-alert: true
+      #     fail-on-alert: true
+      #     alert-comment-cc-users: '@ktrz'
+
+      # - name: Store benchmark result - separate results repo
+      #   uses: rhysd/github-action-benchmark@v1
+      #   with:
+      #     name: Benchmark.Net Benchmark
+      #     tool: 'benchmarkdotnet'
+      #     output-file-path: examples/benchmarkdotnet/BenchmarkDotNet.Artifacts/results/Sample.Benchmarks-report-full-compressed.json
+      #     github-token: ${{ secrets.BENCHMARK_ACTION_BOT_TOKEN }}
+      #     auto-push: true
+      #     # Show alert with commit comment on detecting possible performance regression
+      #     alert-threshold: '200%'
+      #     comment-on-alert: true
+      #     fail-on-alert: true
+      #     alert-comment-cc-users: '@ktrz'
+      #     gh-repository: 'github.com/benchmark-action/github-action-benchmark-results'

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   benchmark:
-    name: Run Benchmark.Net benchmark example
+    name: Run benchmark
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write  # in order to add a comment to PR

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -44,6 +44,11 @@ jobs:
       - name: Run benchmark
         run: cd benchmark && dotnet run --exporters json --filter '*' -c Release
 
+      - uses: actions/upload-artifact@v4
+        with:
+          name: results
+          path: benchmark/BenchmarkDotNet.Artifacts/results/
+
       # Download previous benchmark result from cache (if exists)
       - name: Download previous benchmark data
         uses: actions/cache@v4

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -71,7 +71,7 @@ jobs:
           comment-always: true
           # Caveat: https://github.com/benchmark-action/github-action-benchmark?tab=readme-ov-file#caveats
           # When triggering on PRs, it's important to have this action "read-only"
-          save-data-file: true
+          save-data-file: ${{ github.event_name != 'pull_request' }}
           alert-threshold: '200%'
           comment-on-alert: true
           fail-on-alert: true

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -15,12 +15,34 @@ jobs:
     name: Run Benchmark.Net benchmark example
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-dotnet@v3
+      - name: Checkout libstapsdt repo
+        uses: actions/checkout@v4
         with:
-          dotnet-version: '8.0.401'  # SDK Version to use. keep in line with examples/benchmarkdotnet/global.json
+          repository: linux-usdt/libstapsdt
+          ref: refs/heads/main
+          path: libstapsdt
+
+      - name: Install libstapsdt
+        run: |
+          set -euxo pipefail
+          cd libstapsdt
+          make
+          sudo make install
+          sudo ldconfig
+        shell: bash
+
+      - name: Checkout DynamicProbes repo
+        uses: actions/checkout@v4
+        with:
+          path: DynamicProbes
+
+      - name: Install dotnet
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '8.0.401'
+
       - name: Run benchmark
-        run: cd benchmark && dotnet run --exporters json --filter '*' -c Release
+        run: cd DynamicProbes/benchmark && dotnet run --exporters json --filter '*' -c Release
 
       # - name: Store benchmark result
       #   uses: rhysd/github-action-benchmark@v1

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -56,6 +56,11 @@ jobs:
           path: ./cache
           key: last-benchmark
 
+      - name: PR comment with file
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          filePath: benchmark/BenchmarkDotNet.Artifacts/results/Benchmark.NotObservedProbeFireBenchmarks-report-github.md
+
       # Caveat: https://github.com/benchmark-action/github-action-benchmark?tab=readme-ov-file#caveats
       # When triggering on PRs, it's important to have this action "read-only"
       - name: Store benchmark result

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -58,8 +58,9 @@ jobs:
           name: Benchmark.Net Benchmark
           tool: 'benchmarkdotnet'
           output-file-path: benchmark/BenchmarkDotNet.Artifacts/results/Benchmark.NotObservedProbeFireBenchmarks-report-full-compressed.json
+          external-data-json-path: ./cache/benchmark-data.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          auto-push: true
+          summary-always: true
           # Show alert with commit comment on detecting possible performance regression
           alert-threshold: '200%'
           comment-on-alert: true

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -8,10 +8,13 @@ on:
     branches:
       - main
 
+
 jobs:
   benchmark:
     name: Run Benchmark.Net benchmark example
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write  # in order to add a comment to PR
     steps:
       - name: Checkout libstapsdt repo
         uses: actions/checkout@v4

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: results
-          path: benchmark/BenchmarkDotNet.Artifacts/results/
+          path: BenchmarkDotNet.Artifacts/results/
 
       # Download previous benchmark result from cache (if exists)
       - name: Download previous benchmark data
@@ -64,7 +64,7 @@ jobs:
         with:
           name: Benchmark (compared to main)  # bench data is cached inside `external-data-json-path` by this name
           tool: 'benchmarkdotnet'
-          output-file-path: benchmark/BenchmarkDotNet.Artifacts/results/Benchmark.UnobservedProbeFireBenchmarks-report-full-compressed.json
+          output-file-path: BenchmarkDotNet.Artifacts/results/Benchmark.UnobservedProbeFireBenchmarks-report-full-compressed.json
           external-data-json-path: ./cache/benchmark-data.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
           summary-always: true

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -71,7 +71,7 @@ jobs:
           comment-always: true
           # Caveat: https://github.com/benchmark-action/github-action-benchmark?tab=readme-ov-file#caveats
           # When triggering on PRs, it's important to have this action "read-only"
-          save-data-file: ${{ github.event_name != 'pull_request' }}
+          save-data-file: true
           alert-threshold: '200%'
           comment-on-alert: true
           fail-on-alert: true

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -56,15 +56,15 @@ jobs:
           path: ./cache
           key: last-benchmark
 
-      - name: PR comment with file
-        uses: thollander/actions-comment-pull-request@v2
-        with:
-          filePath: benchmark/BenchmarkDotNet.Artifacts/results/Benchmark.NotObservedProbeFireBenchmarks-report-github.md
+      # - name: PR comment with file
+      #   uses: thollander/actions-comment-pull-request@v2
+      #   with:
+      #     filePath: benchmark/BenchmarkDotNet.Artifacts/results/Benchmark.NotObservedProbeFireBenchmarks-report-github.md
 
       # Caveat: https://github.com/benchmark-action/github-action-benchmark?tab=readme-ov-file#caveats
       # When triggering on PRs, it's important to have this action "read-only"
       - name: Store benchmark result
-        uses: gukoff/github-action-benchmark@main
+        uses: gukoff/github-action-benchmark@v2
         with:
           name: Benchmark.Net Benchmark
           tool: 'benchmarkdotnet'

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -64,7 +64,7 @@ jobs:
         with:
           name: Benchmark (compared to main)  # bench data is cached inside `external-data-json-path` by this name
           tool: 'benchmarkdotnet'
-          output-file-path: benchmark/BenchmarkDotNet.Artifacts/results/Benchmark.NotObservedProbeFireBenchmarks-report-full-compressed.json
+          output-file-path: benchmark/BenchmarkDotNet.Artifacts/results/Benchmark.UnobservedProbeFireBenchmarks-report-full-compressed.json
           external-data-json-path: ./cache/benchmark-data.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
           summary-always: true

--- a/.github/workflows/warm-up-cache.yaml
+++ b/.github/workflows/warm-up-cache.yaml
@@ -1,0 +1,21 @@
+name: Warm up the caches
+
+on:
+  schedule:
+    - cron: '0 0 * * */3'
+    # "GitHub will remove any cache entries that have not been accessed in over 7 days".
+    # This schedule will touch the cache 2 times a week at midnight.
+    #
+    # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy
+
+
+jobs:
+  benchmark:
+    name: Checkout the caches
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout last-benchmark
+        uses: actions/cache@v4
+        with:
+          path: ./cache
+          key: last-benchmark

--- a/.github/workflows/warm-up-cache.yaml
+++ b/.github/workflows/warm-up-cache.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout last-benchmark
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: ./cache
           key: last-benchmark

--- a/DynamicProbes.sln
+++ b/DynamicProbes.sln
@@ -11,6 +11,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		README.md = README.md
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Benchmark", "benchmark\Benchmark.csproj", "{2F9E49F9-1B8C-4170-8FF1-313BEF57D91C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,10 @@ Global
 		{1B1F3A57-1538-4C11-ABD8-7024A4ABA2A7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1B1F3A57-1538-4C11-ABD8-7024A4ABA2A7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1B1F3A57-1538-4C11-ABD8-7024A4ABA2A7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2F9E49F9-1B8C-4170-8FF1-313BEF57D91C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2F9E49F9-1B8C-4170-8FF1-313BEF57D91C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2F9E49F9-1B8C-4170-8FF1-313BEF57D91C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2F9E49F9-1B8C-4170-8FF1-313BEF57D91C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/benchmark/Benchmark.csproj
+++ b/benchmark/Benchmark.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
+    <ProjectReference Include="..\src\DynamicProbes.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/benchmark/Program.cs
+++ b/benchmark/Program.cs
@@ -8,7 +8,7 @@ namespace Benchmark;
 [JsonExporterAttribute.Full]
 [JsonExporterAttribute.FullCompressed]
 [SimpleJob(RuntimeMoniker.NativeAot80)]
-public class NotObservedProbeFireBenchmarks
+public class UnobservedProbeFireBenchmarks
 {
     nint provider;
     nint probe1;
@@ -67,6 +67,6 @@ public static class Program
 {
     public static void Main()
     {
-        _ = BenchmarkRunner.Run<NotObservedProbeFireBenchmarks>();
+        _ = BenchmarkRunner.Run<UnobservedProbeFireBenchmarks>();
     }
 }

--- a/benchmark/Program.cs
+++ b/benchmark/Program.cs
@@ -1,13 +1,12 @@
 namespace MyBenchmarks;
 
-using System.Security.Cryptography;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Running;
 using Libstapsdt;
 
 public class Benchmarks
 {
-    private SDTProvider_t provider;
+    private nint provider;
     private nint probe;
     private readonly long arg1 = 1234567890123456789;
     private readonly long arg2 = 2234567890123456789;
@@ -20,20 +19,20 @@ public class Benchmarks
     public void GlobalSetup()
     {
         provider = Libstapsdt.providerInit("myprovider");
-        probe = Libstapsdt.providerAddProbe(ref provider, "myprobe1", 1, ArgType_t.Int64);
-        probe = Libstapsdt.providerAddProbe(ref provider, "myprobe2", 2, ArgType_t.Int64, ArgType_t.Int64);
-        probe = Libstapsdt.providerAddProbe(ref provider, "myprobe3", 3, ArgType_t.Int64, ArgType_t.Int64, ArgType_t.Int64);
-        probe = Libstapsdt.providerAddProbe(ref provider, "myprobe4", 4, ArgType_t.Int64, ArgType_t.Int64, ArgType_t.Int64, ArgType_t.Int64);
-        probe = Libstapsdt.providerAddProbe(ref provider, "myprobe5", 5, ArgType_t.Int64, ArgType_t.Int64, ArgType_t.Int64, ArgType_t.Int64, ArgType_t.Int64);
-        probe = Libstapsdt.providerAddProbe(ref provider, "myprobe6", 6, ArgType_t.Int64, ArgType_t.Int64, ArgType_t.Int64, ArgType_t.Int64, ArgType_t.Int64, ArgType_t.Int64);
-        _ = Libstapsdt.providerLoad(ref provider);
+        probe = Libstapsdt.providerAddProbe(provider, "myprobe1", 1, ArgType_t.Int64);
+        probe = Libstapsdt.providerAddProbe(provider, "myprobe2", 2, ArgType_t.Int64, ArgType_t.Int64);
+        probe = Libstapsdt.providerAddProbe(provider, "myprobe3", 3, ArgType_t.Int64, ArgType_t.Int64, ArgType_t.Int64);
+        probe = Libstapsdt.providerAddProbe(provider, "myprobe4", 4, ArgType_t.Int64, ArgType_t.Int64, ArgType_t.Int64, ArgType_t.Int64);
+        probe = Libstapsdt.providerAddProbe(provider, "myprobe5", 5, ArgType_t.Int64, ArgType_t.Int64, ArgType_t.Int64, ArgType_t.Int64, ArgType_t.Int64);
+        probe = Libstapsdt.providerAddProbe(provider, "myprobe6", 6, ArgType_t.Int64, ArgType_t.Int64, ArgType_t.Int64, ArgType_t.Int64, ArgType_t.Int64, ArgType_t.Int64);
+        _ = Libstapsdt.providerLoad(provider);
     }
 
     [GlobalCleanup]
     public void GlobalCleanup()
     {
-        _ = Libstapsdt.providerUnload(ref provider);
-        Libstapsdt.providerDestroy(ref provider);
+        _ = Libstapsdt.providerUnload(provider);
+        Libstapsdt.providerDestroy(provider);
     }
 
     [Benchmark]

--- a/benchmark/Program.cs
+++ b/benchmark/Program.cs
@@ -23,12 +23,12 @@ public class NotObservedProbeFireBenchmarks
     public void GlobalSetup()
     {
         provider = Libstapsdt.providerInit("myprovider");
-        probe = Libstapsdt.providerAddProbe(provider, "myprobe1", 1, ArgType_t.Int64);
-        probe = Libstapsdt.providerAddProbe(provider, "myprobe2", 2, ArgType_t.Int64, ArgType_t.Int64);
-        probe = Libstapsdt.providerAddProbe(provider, "myprobe3", 3, ArgType_t.Int64, ArgType_t.Int64, ArgType_t.Int64);
-        probe = Libstapsdt.providerAddProbe(provider, "myprobe4", 4, ArgType_t.Int64, ArgType_t.Int64, ArgType_t.Int64, ArgType_t.Int64);
-        probe = Libstapsdt.providerAddProbe(provider, "myprobe5", 5, ArgType_t.Int64, ArgType_t.Int64, ArgType_t.Int64, ArgType_t.Int64, ArgType_t.Int64);
-        probe = Libstapsdt.providerAddProbe(provider, "myprobe6", 6, ArgType_t.Int64, ArgType_t.Int64, ArgType_t.Int64, ArgType_t.Int64, ArgType_t.Int64, ArgType_t.Int64);
+        probe = Libstapsdt.providerAddProbe(provider, "myprobe1", ArgType_t.Int64);
+        probe = Libstapsdt.providerAddProbe(provider, "myprobe2", ArgType_t.Int64, ArgType_t.Int64);
+        probe = Libstapsdt.providerAddProbe(provider, "myprobe3", ArgType_t.Int64, ArgType_t.Int64, ArgType_t.Int64);
+        probe = Libstapsdt.providerAddProbe(provider, "myprobe4", ArgType_t.Int64, ArgType_t.Int64, ArgType_t.Int64, ArgType_t.Int64);
+        probe = Libstapsdt.providerAddProbe(provider, "myprobe5", ArgType_t.Int64, ArgType_t.Int64, ArgType_t.Int64, ArgType_t.Int64, ArgType_t.Int64);
+        probe = Libstapsdt.providerAddProbe(provider, "myprobe6", ArgType_t.Int64, ArgType_t.Int64, ArgType_t.Int64, ArgType_t.Int64, ArgType_t.Int64, ArgType_t.Int64);
         _ = Libstapsdt.providerLoad(provider);
     }
 

--- a/benchmark/Program.cs
+++ b/benchmark/Program.cs
@@ -17,12 +17,6 @@ public class UnobservedProbeFireBenchmarks
     nint probe4;
     nint probe5;
     nint probe6;
-    readonly long arg1 = 1234567890123456789;
-    readonly long arg2 = 2234567890123456789;
-    readonly long arg3 = 3234567890123456789;
-    readonly long arg4 = 4234567890123456789;
-    readonly long arg5 = 5234567890123456789;
-    readonly long arg6 = 6234567890123456789;
 
     [GlobalSetup]
     public void GlobalSetup()
@@ -44,23 +38,31 @@ public class UnobservedProbeFireBenchmarks
         Libstapsdt.ProviderDestroy(this.provider);
     }
 
-    [Benchmark]
-    public void ArgCount1() => Libstapsdt.ProbeFire(this.probe1, this.arg1);
+    const long Arg1 = 1234567890123456789;
+    const long Arg2 = 2234567890123456789;
+    const long Arg3 = 3234567890123456789;
+    const long Arg4 = 4234567890123456789;
+    const long Arg5 = 5234567890123456789;
+    const long Arg6 = 6234567890123456789;
+
 
     [Benchmark]
-    public void ArgCount2() => Libstapsdt.ProbeFire(this.probe2, this.arg1, this.arg2);
+    public void ArgCount1() => Libstapsdt.ProbeFire(this.probe1, Arg1);
 
     [Benchmark]
-    public void ArgCount3() => Libstapsdt.ProbeFire(this.probe3, this.arg1, this.arg2, this.arg3);
+    public void ArgCount2() => Libstapsdt.ProbeFire(this.probe2, Arg1, Arg2);
 
     [Benchmark]
-    public void ArgCount4() => Libstapsdt.ProbeFire(this.probe4, this.arg1, this.arg2, this.arg3, this.arg4);
+    public void ArgCount3() => Libstapsdt.ProbeFire(this.probe3, Arg1, Arg2, Arg3);
 
     [Benchmark]
-    public void ArgCount5() => Libstapsdt.ProbeFire(this.probe5, this.arg1, this.arg2, this.arg3, this.arg4, this.arg5);
+    public void ArgCount4() => Libstapsdt.ProbeFire(this.probe4, Arg1, Arg2, Arg3, Arg4);
 
     [Benchmark]
-    public void ArgCount6() => Libstapsdt.ProbeFire(this.probe6, this.arg1, this.arg2, this.arg3, this.arg4, this.arg5, this.arg6);
+    public void ArgCount5() => Libstapsdt.ProbeFire(this.probe5, Arg1, Arg2, Arg3, Arg4, Arg5);
+
+    [Benchmark]
+    public void ArgCount6() => Libstapsdt.ProbeFire(this.probe6, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6);
 }
 
 public static class Program

--- a/benchmark/Program.cs
+++ b/benchmark/Program.cs
@@ -1,4 +1,4 @@
-namespace MyBenchmarks;
+namespace Benchmark;
 
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Jobs;

--- a/benchmark/Program.cs
+++ b/benchmark/Program.cs
@@ -1,0 +1,64 @@
+namespace MyBenchmarks;
+
+using System.Security.Cryptography;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Running;
+using Libstapsdt;
+
+public class Benchmarks
+{
+    private SDTProvider_t provider;
+    private nint probe;
+    private readonly long arg1 = 1234567890123456789;
+    private readonly long arg2 = 2234567890123456789;
+    private readonly long arg3 = 3234567890123456789;
+    private readonly long arg4 = 4234567890123456789;
+    private readonly long arg5 = 5234567890123456789;
+    private readonly long arg6 = 6234567890123456789;
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        provider = Libstapsdt.providerInit("myprovider");
+        probe = Libstapsdt.providerAddProbe(ref provider, "myprobe1", 1, ArgType_t.Int64);
+        probe = Libstapsdt.providerAddProbe(ref provider, "myprobe2", 2, ArgType_t.Int64, ArgType_t.Int64);
+        probe = Libstapsdt.providerAddProbe(ref provider, "myprobe3", 3, ArgType_t.Int64, ArgType_t.Int64, ArgType_t.Int64);
+        probe = Libstapsdt.providerAddProbe(ref provider, "myprobe4", 4, ArgType_t.Int64, ArgType_t.Int64, ArgType_t.Int64, ArgType_t.Int64);
+        probe = Libstapsdt.providerAddProbe(ref provider, "myprobe5", 5, ArgType_t.Int64, ArgType_t.Int64, ArgType_t.Int64, ArgType_t.Int64, ArgType_t.Int64);
+        probe = Libstapsdt.providerAddProbe(ref provider, "myprobe6", 6, ArgType_t.Int64, ArgType_t.Int64, ArgType_t.Int64, ArgType_t.Int64, ArgType_t.Int64, ArgType_t.Int64);
+        _ = Libstapsdt.providerLoad(ref provider);
+    }
+
+    [GlobalCleanup]
+    public void GlobalCleanup()
+    {
+        _ = Libstapsdt.providerUnload(ref provider);
+        Libstapsdt.providerDestroy(ref provider);
+    }
+
+    [Benchmark]
+    public void ArgCount1() => Libstapsdt.probeFire(probe, arg1);
+
+    [Benchmark]
+    public void ArgCount2() => Libstapsdt.probeFire(probe, arg1, arg2);
+
+    [Benchmark]
+    public void ArgCount3() => Libstapsdt.probeFire(probe, arg1, arg2, arg3);
+
+    [Benchmark]
+    public void ArgCount4() => Libstapsdt.probeFire(probe, arg1, arg2, arg3, arg4);
+
+    [Benchmark]
+    public void ArgCount5() => Libstapsdt.probeFire(probe, arg1, arg2, arg3, arg4, arg5);
+
+    [Benchmark]
+    public void ArgCount6() => Libstapsdt.probeFire(probe, arg1, arg2, arg3, arg4, arg5, arg6);
+}
+
+public class Program
+{
+    public static void Main(string[] args)
+    {
+        var summary = BenchmarkRunner.Run<Benchmarks>();
+    }
+}

--- a/benchmark/Program.cs
+++ b/benchmark/Program.cs
@@ -1,67 +1,72 @@
-namespace Benchmark;
-
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Running;
-using Libstapsdt;
+using LibstapsdtPinvokes;
+
+namespace Benchmark;
 
 [JsonExporterAttribute.Full]
 [JsonExporterAttribute.FullCompressed]
 [SimpleJob(RuntimeMoniker.NativeAot80)]
 public class NotObservedProbeFireBenchmarks
 {
-    private nint provider;
-    private nint probe;
-    private readonly long arg1 = 1234567890123456789;
-    private readonly long arg2 = 2234567890123456789;
-    private readonly long arg3 = 3234567890123456789;
-    private readonly long arg4 = 4234567890123456789;
-    private readonly long arg5 = 5234567890123456789;
-    private readonly long arg6 = 6234567890123456789;
+    nint provider;
+    nint probe1;
+    nint probe2;
+    nint probe3;
+    nint probe4;
+    nint probe5;
+    nint probe6;
+    readonly long arg1 = 1234567890123456789;
+    readonly long arg2 = 2234567890123456789;
+    readonly long arg3 = 3234567890123456789;
+    readonly long arg4 = 4234567890123456789;
+    readonly long arg5 = 5234567890123456789;
+    readonly long arg6 = 6234567890123456789;
 
     [GlobalSetup]
     public void GlobalSetup()
     {
-        provider = Libstapsdt.providerInit("myprovider");
-        probe = Libstapsdt.providerAddProbe(provider, "myprobe1", ArgType_t.Int64);
-        probe = Libstapsdt.providerAddProbe(provider, "myprobe2", ArgType_t.Int64, ArgType_t.Int64);
-        probe = Libstapsdt.providerAddProbe(provider, "myprobe3", ArgType_t.Int64, ArgType_t.Int64, ArgType_t.Int64);
-        probe = Libstapsdt.providerAddProbe(provider, "myprobe4", ArgType_t.Int64, ArgType_t.Int64, ArgType_t.Int64, ArgType_t.Int64);
-        probe = Libstapsdt.providerAddProbe(provider, "myprobe5", ArgType_t.Int64, ArgType_t.Int64, ArgType_t.Int64, ArgType_t.Int64, ArgType_t.Int64);
-        probe = Libstapsdt.providerAddProbe(provider, "myprobe6", ArgType_t.Int64, ArgType_t.Int64, ArgType_t.Int64, ArgType_t.Int64, ArgType_t.Int64, ArgType_t.Int64);
-        _ = Libstapsdt.providerLoad(provider);
+        this.provider = Libstapsdt.ProviderInit("myprovider");
+        this.probe1 = Libstapsdt.ProviderAddProbe(this.provider, "myprobe1", ArgType.Int64);
+        this.probe2 = Libstapsdt.ProviderAddProbe(this.provider, "myprobe2", ArgType.Int64, ArgType.Int64);
+        this.probe3 = Libstapsdt.ProviderAddProbe(this.provider, "myprobe3", ArgType.Int64, ArgType.Int64, ArgType.Int64);
+        this.probe4 = Libstapsdt.ProviderAddProbe(this.provider, "myprobe4", ArgType.Int64, ArgType.Int64, ArgType.Int64, ArgType.Int64);
+        this.probe5 = Libstapsdt.ProviderAddProbe(this.provider, "myprobe5", ArgType.Int64, ArgType.Int64, ArgType.Int64, ArgType.Int64, ArgType.Int64);
+        this.probe6 = Libstapsdt.ProviderAddProbe(this.provider, "myprobe6", ArgType.Int64, ArgType.Int64, ArgType.Int64, ArgType.Int64, ArgType.Int64, ArgType.Int64);
+        _ = Libstapsdt.ProviderLoad(this.provider);
     }
 
     [GlobalCleanup]
     public void GlobalCleanup()
     {
-        _ = Libstapsdt.providerUnload(provider);
-        Libstapsdt.providerDestroy(provider);
+        _ = Libstapsdt.ProviderUnload(this.provider);
+        Libstapsdt.ProviderDestroy(this.provider);
     }
 
     [Benchmark]
-    public void ArgCount1() => Libstapsdt.probeFire(probe, arg1);
+    public void ArgCount1() => Libstapsdt.ProbeFire(this.probe1, this.arg1);
 
     [Benchmark]
-    public void ArgCount2() => Libstapsdt.probeFire(probe, arg1, arg2);
+    public void ArgCount2() => Libstapsdt.ProbeFire(this.probe2, this.arg1, this.arg2);
 
     [Benchmark]
-    public void ArgCount3() => Libstapsdt.probeFire(probe, arg1, arg2, arg3);
+    public void ArgCount3() => Libstapsdt.ProbeFire(this.probe3, this.arg1, this.arg2, this.arg3);
 
     [Benchmark]
-    public void ArgCount4() => Libstapsdt.probeFire(probe, arg1, arg2, arg3, arg4);
+    public void ArgCount4() => Libstapsdt.ProbeFire(this.probe4, this.arg1, this.arg2, this.arg3, this.arg4);
 
     [Benchmark]
-    public void ArgCount5() => Libstapsdt.probeFire(probe, arg1, arg2, arg3, arg4, arg5);
+    public void ArgCount5() => Libstapsdt.ProbeFire(this.probe5, this.arg1, this.arg2, this.arg3, this.arg4, this.arg5);
 
     [Benchmark]
-    public void ArgCount6() => Libstapsdt.probeFire(probe, arg1, arg2, arg3, arg4, arg5, arg6);
+    public void ArgCount6() => Libstapsdt.ProbeFire(this.probe6, this.arg1, this.arg2, this.arg3, this.arg4, this.arg5, this.arg6);
 }
 
-public class Program
+public static class Program
 {
-    public static void Main(string[] args)
+    public static void Main()
     {
-        var summary = BenchmarkRunner.Run<NotObservedProbeFireBenchmarks>();
+        _ = BenchmarkRunner.Run<NotObservedProbeFireBenchmarks>();
     }
 }

--- a/benchmark/Program.cs
+++ b/benchmark/Program.cs
@@ -1,9 +1,14 @@
 namespace MyBenchmarks;
 
 using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Running;
 using Libstapsdt;
 
+[SimpleJob(RuntimeMoniker.Net481, baseline: true)]
+[SimpleJob(RuntimeMoniker.Net80)]
+[SimpleJob(RuntimeMoniker.NativeAot80)]
+[RPlotExporter]
 public class Benchmarks
 {
     private nint provider;

--- a/benchmark/Program.cs
+++ b/benchmark/Program.cs
@@ -5,9 +5,10 @@ using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Running;
 using Libstapsdt;
 
+[JsonExporterAttribute.Full]
+[JsonExporterAttribute.FullCompressed]
 [SimpleJob(RuntimeMoniker.Net80, baseline: true)]
 [SimpleJob(RuntimeMoniker.NativeAot80)]
-[RPlotExporter]
 public class Benchmarks
 {
     private nint provider;

--- a/benchmark/Program.cs
+++ b/benchmark/Program.cs
@@ -5,8 +5,7 @@ using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Running;
 using Libstapsdt;
 
-[SimpleJob(RuntimeMoniker.Net481, baseline: true)]
-[SimpleJob(RuntimeMoniker.Net80)]
+[SimpleJob(RuntimeMoniker.Net80, baseline: true)]
 [SimpleJob(RuntimeMoniker.NativeAot80)]
 [RPlotExporter]
 public class Benchmarks

--- a/benchmark/Program.cs
+++ b/benchmark/Program.cs
@@ -9,7 +9,7 @@ using Libstapsdt;
 [JsonExporterAttribute.FullCompressed]
 [SimpleJob(RuntimeMoniker.Net80, baseline: true)]
 [SimpleJob(RuntimeMoniker.NativeAot80)]
-public class Benchmarks
+public class NotObservedProbeFireBenchmarks
 {
     private nint provider;
     private nint probe;
@@ -63,6 +63,6 @@ public class Program
 {
     public static void Main(string[] args)
     {
-        var summary = BenchmarkRunner.Run<Benchmarks>();
+        var summary = BenchmarkRunner.Run<NotObservedProbeFireBenchmarks>();
     }
 }

--- a/benchmark/Program.cs
+++ b/benchmark/Program.cs
@@ -7,7 +7,6 @@ using Libstapsdt;
 
 [JsonExporterAttribute.Full]
 [JsonExporterAttribute.FullCompressed]
-[SimpleJob(RuntimeMoniker.Net80, baseline: true)]
 [SimpleJob(RuntimeMoniker.NativeAot80)]
 public class NotObservedProbeFireBenchmarks
 {

--- a/benchmark/Properties/launchSettings.json
+++ b/benchmark/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+    "profiles": {
+        "Benchmark": {
+            "commandName": "Project",
+            "commandLineArgs": "--exporters json --filter *"
+        }
+    }
+}

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100",
-    "rollForward": "latestFeature"
+    "version": "8.0.400",
+    "rollForward": "latestPatch"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "version": "8.0.100",
-    "rollForward": "latestPatch"
+    "rollForward": "latestFeature"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.400",
+    "version": "8.0.100",
     "rollForward": "latestPatch"
   }
 }

--- a/src/Libstapsdt.cs
+++ b/src/Libstapsdt.cs
@@ -6,7 +6,10 @@ using SdtProviderPtr = nint;
 #pragma warning disable CA5392 // Use DefaultDllImportSearchPaths attribute for P/Invokes
                                // ...but it has no effect on non-Windows platforms or the Mono runtime.
 
-namespace Libstapsdt;
+#pragma warning disable CA1401 // P/Invokes should not be visible
+                               // ...the point of this library is to make P/Invokes visible.
+
+namespace LibstapsdtPinvokes;
 
 // Source: https://github.com/linux-usdt/libstapsdt/blob/0d53f987b0787362fd9c16a93cdad2c273d809fc/src/libstapsdt.h
 
@@ -125,7 +128,9 @@ enum SdtError // SDTError_t
     SharedLibraryCloseError = 4   // sharedLibraryCloseError
 }
 
-enum ArgType // ArgType_t
+
+#pragma warning disable CA1720 // Identifiers should not contain type names
+public enum ArgType // ArgType_t
 {
     NoArg = 0,  // noarg
     UInt8 = 1,  // uint8
@@ -138,7 +143,9 @@ enum ArgType // ArgType_t
     Int64 = -8  // int64
 }
 
-enum MemfdOption // MemFDOption_t
+#pragma warning restore CA1720 // Identifiers should not contain type names
+
+public enum MemfdOption // MemFDOption_t
 {
     Disabled = 0, // memfd_disabled
     Enabled = 1   // memfd_enabled

--- a/src/Libstapsdt.cs
+++ b/src/Libstapsdt.cs
@@ -5,7 +5,7 @@ using ProbePtr = System.IntPtr;
 
 // Source: https://github.com/linux-usdt/libstapsdt/blob/0d53f987b0787362fd9c16a93cdad2c273d809fc/src/libstapsdt.h
 
-static class Libstapsdt
+public static class Libstapsdt
 {
     private const string LibstapsdtLibrary = "libstapsdt.so.0";
 
@@ -73,7 +73,7 @@ static class Libstapsdt
     public static extern bool probeIsEnabled(ProbePtr probe);  // return 1 if true, 0 if false
 }
 
-enum SDTError_t
+public enum SDTError_t
 {
     NoError = -1,
     ElfCreationError = 0,
@@ -83,7 +83,7 @@ enum SDTError_t
     SharedLibraryCloseError = 4
 }
 
-enum ArgType_t
+public enum ArgType_t
 {
     NoArg = 0,
     UInt8 = 1,
@@ -96,7 +96,7 @@ enum ArgType_t
     Int64 = -8
 }
 
-enum MemFDOption_t
+public enum MemFDOption_t
 {
     MemfdDisabled = 0,
     MemfdEnabled = 1
@@ -105,7 +105,7 @@ enum MemFDOption_t
 // Structs from the C header file
 
 [StructLayout(LayoutKind.Sequential)]
-struct SDTProvider_t
+public struct SDTProvider_t
 {
     public IntPtr Name;  // char*
     public IntPtr Probes; // struct SDTProbeList_t*

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -3,23 +3,22 @@
 
 using System.Globalization;
 using System.Runtime.InteropServices;
-using Libstapsdt;
-
+using LibstapsdtPinvokes;
 
 try
 {
     var providerName = "myprovider";
     var probeName = "myprobe";
 
-    var provider = Libstapsdt.Libstapsdt.ProviderInit(providerName);
+    var provider = Libstapsdt.ProviderInit(providerName);
 
-    //Libstapsdt.Libstapsdt.ProviderUseMemfd(ref provider, MemFDOption_t.MemfdEnabled);
+    _ = Libstapsdt.ProviderUseMemfd(provider, MemfdOption.Enabled);
 
-    var probe = Libstapsdt.Libstapsdt.ProviderAddProbe(provider, probeName, ArgType.Int64, ArgType.UInt64);
+    var probe = Libstapsdt.ProviderAddProbe(provider, probeName, ArgType.Int64, ArgType.UInt64);
     if (probe == IntPtr.Zero)
         throw new Exception("Could not initialize the probe");
 
-    var res = Libstapsdt.Libstapsdt.ProviderLoad(provider);
+    var res = Libstapsdt.ProviderLoad(provider);
     if (res != 0)
         throw new Exception("Could not load provider");
 
@@ -33,13 +32,13 @@ try
         var isoTimeStringPtr = Marshal.StringToCoTaskMemUTF8(isoTimeString);
         try
         {
-            Libstapsdt.Libstapsdt.ProbeFire(probe, val, isoTimeStringPtr);
+            Libstapsdt.ProbeFire(probe, val, isoTimeStringPtr);
         }
         finally
         {
             Marshal.FreeCoTaskMem(isoTimeStringPtr);
         }
-        Console.WriteLine("Probe fired! Probe is currently {0}", Libstapsdt.Libstapsdt.ProbeIsEnabled(probe) ? "watched" : "not watched");
+        Console.WriteLine("Probe fired! Probe is currently {0}", Libstapsdt.ProbeIsEnabled(probe) ? "watched" : "not watched");
         Thread.Sleep(500);
     }
 }


### PR DESCRIPTION
- Project with 6 benchmarks for firing the probe **while not monitored**
- PR check that compares performance to the `main` branch (benchmark numbers [seem to spread +-25%](https://github.com/benchmark-action/github-action-benchmark?tab=readme-ov-file#stability-of-virtual-environment) on the currently used non-dedicated CI agents)
- Only NativeAOT 8.0 performance is measured. Regular .NET [was seen to be slower](https://github.com/gukoff/DynamicProbes/pull/7#issuecomment-2325205264) during testing.
- The benchmark can be run manually `dotnet run --exporters json --filter '*' -c Release`. I can also add a `Makefile` to simplify this command to `make bench`.
- This action must run [on the default branch](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows#matching-a-cache-key) in this repo at least once in order to cache the "reference" benchmark results and to enable benchmark comparisons for all PRs.

Next steps: 
- measure performance while probed by `bpftrace`. It must be significantly slower due to the 2 context switches from userspace to kernel and back.
- benchmark against the builtin tracing tooling in dotnet.