### PR TITLE
Relax requirement for dotnet version

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.400",
-    "rollForward": "latestPatch"
+    "version": "8.0.100",
+    "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
It's a pain to install something newer than 8.0.108 on Ubuntu 22.04.

This how-to doesn't work: https://learn.microsoft.com/en-us/dotnet/core/install/linux-scripted-manual#example
Leaves me with `dotnet --list-sdks` finding no SDKs even though the env vars `PATH` and `DOTNET_ROOT` are set correctly, and the newest SDKs are indeed downloaded into the DOTNET_ROOT folder.