### PR TITLE
Remove redundant calling convention specification

### DIFF
--- a/src/Generated/net8.0/Microsoft.Interop.LibraryImportGenerator/Microsoft.Interop.LibraryImportGenerator/LibraryImports.g.cs
+++ b/src/Generated/net8.0/Microsoft.Interop.LibraryImportGenerator/Microsoft.Interop.LibraryImportGenerator/LibraryImports.g.cs
@@ -30,7 +30,6 @@ namespace LibstapsdtPinvokes
             return __retVal;
             // Local P/Invoke
             [global::System.Runtime.InteropServices.DllImportAttribute("libstapsdt.so.0", EntryPoint = "providerInit", ExactSpelling = true)]
-            [global::System.Runtime.InteropServices.UnmanagedCallConvAttribute(CallConvs = new global::System.Type[] { typeof(global::System.Runtime.CompilerServices.CallConvCdecl) })]
             static extern unsafe nint __PInvoke(byte* __name_native);
         }
     }
@@ -74,7 +73,6 @@ namespace LibstapsdtPinvokes
             return __retVal;
             // Local P/Invoke
             [global::System.Runtime.InteropServices.DllImportAttribute("libstapsdt.so.0", EntryPoint = "providerAddProbe", ExactSpelling = true)]
-            [global::System.Runtime.InteropServices.UnmanagedCallConvAttribute(CallConvs = new global::System.Type[] { typeof(global::System.Runtime.CompilerServices.CallConvCdecl) })]
             static extern unsafe nint __PInvoke(nint __provider_native, byte* __name_native, int __argCount_native, global::LibstapsdtPinvokes.ArgType __arg1_native);
         }
     }
@@ -110,7 +108,6 @@ namespace LibstapsdtPinvokes
             return __retVal;
             // Local P/Invoke
             [global::System.Runtime.InteropServices.DllImportAttribute("libstapsdt.so.0", EntryPoint = "providerAddProbe", ExactSpelling = true)]
-            [global::System.Runtime.InteropServices.UnmanagedCallConvAttribute(CallConvs = new global::System.Type[] { typeof(global::System.Runtime.CompilerServices.CallConvCdecl) })]
             static extern unsafe nint __PInvoke(nint __provider_native, byte* __name_native, int __argCount_native, global::LibstapsdtPinvokes.ArgType __arg1_native, global::LibstapsdtPinvokes.ArgType __arg2_native);
         }
     }
@@ -146,7 +143,6 @@ namespace LibstapsdtPinvokes
             return __retVal;
             // Local P/Invoke
             [global::System.Runtime.InteropServices.DllImportAttribute("libstapsdt.so.0", EntryPoint = "providerAddProbe", ExactSpelling = true)]
-            [global::System.Runtime.InteropServices.UnmanagedCallConvAttribute(CallConvs = new global::System.Type[] { typeof(global::System.Runtime.CompilerServices.CallConvCdecl) })]
             static extern unsafe nint __PInvoke(nint __provider_native, byte* __name_native, int __argCount_native, global::LibstapsdtPinvokes.ArgType __arg1_native, global::LibstapsdtPinvokes.ArgType __arg2_native, global::LibstapsdtPinvokes.ArgType __arg3_native);
         }
     }
@@ -182,7 +178,6 @@ namespace LibstapsdtPinvokes
             return __retVal;
             // Local P/Invoke
             [global::System.Runtime.InteropServices.DllImportAttribute("libstapsdt.so.0", EntryPoint = "providerAddProbe", ExactSpelling = true)]
-            [global::System.Runtime.InteropServices.UnmanagedCallConvAttribute(CallConvs = new global::System.Type[] { typeof(global::System.Runtime.CompilerServices.CallConvCdecl) })]
             static extern unsafe nint __PInvoke(nint __provider_native, byte* __name_native, int __argCount_native, global::LibstapsdtPinvokes.ArgType __arg1_native, global::LibstapsdtPinvokes.ArgType __arg2_native, global::LibstapsdtPinvokes.ArgType __arg3_native, global::LibstapsdtPinvokes.ArgType __arg4_native);
         }
     }
@@ -218,7 +213,6 @@ namespace LibstapsdtPinvokes
             return __retVal;
             // Local P/Invoke
             [global::System.Runtime.InteropServices.DllImportAttribute("libstapsdt.so.0", EntryPoint = "providerAddProbe", ExactSpelling = true)]
-            [global::System.Runtime.InteropServices.UnmanagedCallConvAttribute(CallConvs = new global::System.Type[] { typeof(global::System.Runtime.CompilerServices.CallConvCdecl) })]
             static extern unsafe nint __PInvoke(nint __provider_native, byte* __name_native, int __argCount_native, global::LibstapsdtPinvokes.ArgType __arg1_native, global::LibstapsdtPinvokes.ArgType __arg2_native, global::LibstapsdtPinvokes.ArgType __arg3_native, global::LibstapsdtPinvokes.ArgType __arg4_native, global::LibstapsdtPinvokes.ArgType __arg5_native);
         }
     }
@@ -254,7 +248,6 @@ namespace LibstapsdtPinvokes
             return __retVal;
             // Local P/Invoke
             [global::System.Runtime.InteropServices.DllImportAttribute("libstapsdt.so.0", EntryPoint = "providerAddProbe", ExactSpelling = true)]
-            [global::System.Runtime.InteropServices.UnmanagedCallConvAttribute(CallConvs = new global::System.Type[] { typeof(global::System.Runtime.CompilerServices.CallConvCdecl) })]
             static extern unsafe nint __PInvoke(nint __provider_native, byte* __name_native, int __argCount_native, global::LibstapsdtPinvokes.ArgType __arg1_native, global::LibstapsdtPinvokes.ArgType __arg2_native, global::LibstapsdtPinvokes.ArgType __arg3_native, global::LibstapsdtPinvokes.ArgType __arg4_native, global::LibstapsdtPinvokes.ArgType __arg5_native, global::LibstapsdtPinvokes.ArgType __arg6_native);
         }
     }
@@ -358,7 +351,6 @@ namespace LibstapsdtPinvokes
             return __retVal;
             // Local P/Invoke
             [global::System.Runtime.InteropServices.DllImportAttribute("libstapsdt.so.0", EntryPoint = "probeIsEnabled", ExactSpelling = true)]
-            [global::System.Runtime.InteropServices.UnmanagedCallConvAttribute(CallConvs = new global::System.Type[] { typeof(global::System.Runtime.CompilerServices.CallConvCdecl) })]
             static extern unsafe int __PInvoke(nint __probe_native);
         }
     }

--- a/src/Libstapsdt.cs
+++ b/src/Libstapsdt.cs
@@ -19,11 +19,9 @@ public static partial class Libstapsdt
 
     // P/Invoke function declarations
     [LibraryImport(LibstapsdtLibrary, EntryPoint = "providerInit", StringMarshalling = StringMarshalling.Utf8)]
-    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial SdtProviderPtr ProviderInit(string name);
 
     [LibraryImport(LibstapsdtLibrary, EntryPoint = "providerUseMemfd")]
-    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial int ProviderUseMemfd(SdtProviderPtr provider, MemfdOption option);
 
     // Overloads for providerAddProbe for different argument counts
@@ -47,73 +45,56 @@ public static partial class Libstapsdt
         ProviderAddProbe(provider, name, 6, arg1, arg2, arg3, arg4, arg5, arg6);
 
     [LibraryImport(LibstapsdtLibrary, EntryPoint = "providerAddProbe", StringMarshalling = StringMarshalling.Utf8)]
-    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     private static partial ProbePtr ProviderAddProbe(SdtProviderPtr provider, string name, int argCount, ArgType arg1);
 
     [LibraryImport(LibstapsdtLibrary, EntryPoint = "providerAddProbe", StringMarshalling = StringMarshalling.Utf8)]
-    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     private static partial ProbePtr ProviderAddProbe(SdtProviderPtr provider, string name, int argCount, ArgType arg1, ArgType arg2);
 
     [LibraryImport(LibstapsdtLibrary, EntryPoint = "providerAddProbe", StringMarshalling = StringMarshalling.Utf8)]
-    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     private static partial ProbePtr ProviderAddProbe(SdtProviderPtr provider, string name, int argCount, ArgType arg1, ArgType arg2, ArgType arg3);
 
     [LibraryImport(LibstapsdtLibrary, EntryPoint = "providerAddProbe", StringMarshalling = StringMarshalling.Utf8)]
-    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     private static partial ProbePtr ProviderAddProbe(SdtProviderPtr provider, string name, int argCount, ArgType arg1, ArgType arg2, ArgType arg3, ArgType arg4);
 
     [LibraryImport(LibstapsdtLibrary, EntryPoint = "providerAddProbe", StringMarshalling = StringMarshalling.Utf8)]
-    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     private static partial ProbePtr ProviderAddProbe(SdtProviderPtr provider, string name, int argCount, ArgType arg1, ArgType arg2, ArgType arg3, ArgType arg4, ArgType arg5);
 
     [LibraryImport(LibstapsdtLibrary, EntryPoint = "providerAddProbe", StringMarshalling = StringMarshalling.Utf8)]
-    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     private static partial ProbePtr ProviderAddProbe(SdtProviderPtr provider, string name, int argCount, ArgType arg1, ArgType arg2, ArgType arg3, ArgType arg4, ArgType arg5, ArgType arg6);
 
     [LibraryImport(LibstapsdtLibrary, EntryPoint = "providerLoad")]
-    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial int ProviderLoad(SdtProviderPtr provider);  // return -1 on error, 0 on success
 
     [LibraryImport(LibstapsdtLibrary, EntryPoint = "providerUnload")]
-    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial int ProviderUnload(SdtProviderPtr provider);  // return -1 on error, 0 on success
 
     [LibraryImport(LibstapsdtLibrary, EntryPoint = "providerDestroy")]
-    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial void ProviderDestroy(SdtProviderPtr provider);
 
     // Overloads for probeFire for different argument counts
 
     [LibraryImport(LibstapsdtLibrary, EntryPoint = "probeFire")]
-    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial void ProbeFire(ProbePtr probe);
 
     [LibraryImport(LibstapsdtLibrary, EntryPoint = "probeFire")]
-    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial void ProbeFire(ProbePtr probe, long arg1);
 
     [LibraryImport(LibstapsdtLibrary, EntryPoint = "probeFire")]
-    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial void ProbeFire(ProbePtr probe, long arg1, long arg2);
 
     [LibraryImport(LibstapsdtLibrary, EntryPoint = "probeFire")]
-    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial void ProbeFire(ProbePtr probe, long arg1, long arg2, long arg3);
 
     [LibraryImport(LibstapsdtLibrary, EntryPoint = "probeFire")]
-    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial void ProbeFire(ProbePtr probe, long arg1, long arg2, long arg3, long arg4);
 
     [LibraryImport(LibstapsdtLibrary, EntryPoint = "probeFire")]
-    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial void ProbeFire(ProbePtr probe, long arg1, long arg2, long arg3, long arg4, long arg5);
 
     [LibraryImport(LibstapsdtLibrary, EntryPoint = "probeFire")]
-    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial void ProbeFire(ProbePtr probe, long arg1, long arg2, long arg3, long arg4, long arg5, long arg6);
 
     [LibraryImport(LibstapsdtLibrary, EntryPoint = "probeIsEnabled")]
-    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     [return: MarshalAs(UnmanagedType.Bool)]
     public static partial bool ProbeIsEnabled(ProbePtr probe);  // return 1 if true, 0 if false
 }


### PR DESCRIPTION
This PR removes the calling convention specification that's redundant (since we're [targeting Linux x64](https://github.com/gukoff/DynamicProbes/pull/2)) and therefore just noise. The CLR will pick the default calling convention for the platform at run-time.